### PR TITLE
Updated Pom to support slf4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,16 @@
       <artifactId>mail</artifactId>
       <version>1.5.0-b01</version>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.36</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>1.7.36</version>
+    </dependency>
   </dependencies>
  
   <build>


### PR DESCRIPTION
Fixed error message: SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder", that would appear when generating the pdf